### PR TITLE
Allow for configuration of both tag file name and directories searched

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -28,6 +28,7 @@ dependencies:
 - megaparsec
 - aeson
 - filepath
+- mtl
 
 default-extensions:  OverloadedStrings
 

--- a/src/System/Ctags.hs
+++ b/src/System/Ctags.hs
@@ -1,7 +1,9 @@
 module System.Ctags
     ( TagSearchOutcome(..)
     , CtagItem(..)
+    , CtagsSearchConfig
     , tokensFromFile
+    , tokensFromFile'
     , tokensFromStdin
     ) where
 
@@ -12,7 +14,14 @@ import qualified System.Ctags.Parser as P
 import System.Ctags.Types
 
 tokensFromFile :: MonadIO m => m (Either TagSearchOutcome [CtagItem])
-tokensFromFile = (BF.first UnableToParseTags . P.parse =<<) <$> tagsContent
+tokensFromFile =
+    (BF.first UnableToParseTags . P.parse =<<) <$>
+    tagsContent defaultCtagsSearchConfig
+
+tokensFromFile' ::
+       MonadIO m => CtagsSearchConfig -> m (Either TagSearchOutcome [CtagItem])
+tokensFromFile' config =
+    (BF.first UnableToParseTags . P.parse =<<) <$> tagsContent config
 
 tokensFromStdin :: MonadIO m => m (Either TagSearchOutcome [CtagItem])
 tokensFromStdin = BF.first UnableToParseTags . P.parse <$> stdinContent

--- a/src/System/Ctags/Internal.hs
+++ b/src/System/Ctags/Internal.hs
@@ -1,10 +1,17 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+
 module System.Ctags.Internal
-    ( tagsContent
+    ( CtagsSearchConfig
+    , defaultCtagsSearchConfig
     , stdinContent
+    , tagsContent
     ) where
 
+import Control.Monad.Except (ExceptT, MonadError, runExceptT, throwError)
 import Control.Monad.IO.Class (MonadIO, liftIO)
-import qualified Data.Bifunctor as BF
+import Control.Monad.Reader (MonadReader, ReaderT, asks, runReaderT)
 import qualified Data.ByteString.Lazy as BS
 import qualified Data.Text.Encoding.Error as T
 import qualified Data.Text.Lazy as T
@@ -13,25 +20,48 @@ import System.Ctags.IO
 import System.Ctags.Types
 import qualified System.Directory as D
 
-tagsContent :: MonadIO m => m (Either TagSearchOutcome T.Text)
-tagsContent = readTagsFile =<< findTagsFile
+type AppConfig = MonadReader CtagsSearchConfig
+
+newtype App a = App
+    { runApp :: ReaderT CtagsSearchConfig (ExceptT TagSearchOutcome IO) a
+    } deriving ( Functor
+               , Applicative
+               , Monad
+               , AppConfig
+               , MonadIO
+               , MonadError TagSearchOutcome
+               )
+
+data CtagsSearchConfig = CtagsSearchConfig
+    { tagFileName :: String
+    , tagFileDirectories :: [String]
+    }
+
+defaultCtagsSearchConfig :: CtagsSearchConfig
+defaultCtagsSearchConfig = CtagsSearchConfig "tags" [".git", "tmp", "."]
+
+tagsContent ::
+       MonadIO m => CtagsSearchConfig -> m (Either TagSearchOutcome T.Text)
+tagsContent config = liftIO $ runExceptT (runReaderT (runApp run) config)
+
+run :: App T.Text
+run = readTagsFile =<< findTagsFile
 
 stdinContent :: MonadIO m => m T.Text
 stdinContent = lenientUtf8Decode <$> getContentsLazy
 
-findTagsFile :: MonadIO m => m (Maybe FilePath)
-findTagsFile = findFile possibleTagsFileDirectories "tags"
-  where
-    findFile dirs = liftIO . D.findFile dirs
+findTagsFile :: App FilePath
+findTagsFile = do
+    directories <- asks tagFileDirectories
+    filename <- asks tagFileName
+    maybe (throwError $ TagsFileNotFound directories) return =<<
+        liftIO (D.findFile directories filename)
 
-readTagsFile :: MonadIO m => Maybe String -> m (Either TagSearchOutcome T.Text)
-readTagsFile Nothing =
-    return $ Left $ TagsFileNotFound possibleTagsFileDirectories
-readTagsFile (Just path) =
-    BF.bimap IOError lenientUtf8Decode <$> safeReadFile path
-
-possibleTagsFileDirectories :: [String]
-possibleTagsFileDirectories = [".git", "tmp", "."]
+readTagsFile ::
+       (MonadIO m, MonadError TagSearchOutcome m) => FilePath -> m T.Text
+readTagsFile path =
+    either (throwError . IOError) (return . lenientUtf8Decode) =<<
+    safeReadFile path
 
 lenientUtf8Decode :: BS.ByteString -> T.Text
 lenientUtf8Decode = T.decodeUtf8With T.lenientDecode


### PR DESCRIPTION
What?
=====

This package made a number of assumptions around placement and naming of
tags files. This extracts those assumptions into a set of configuration
settings which can be provided via a separate function.